### PR TITLE
T20 bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ do the SMD assembly.
 
 ### Tools
 
-1. T20 security bit, 2in long
+1. T20 TORX bit, 2in long
 2. Philips #2 screwdriver
 3. Spudger or flathead screwdriver
 4. Soldering iron


### PR DESCRIPTION
Removed security, since T20 TORX security has an actual pin in the center. These are regular T20 TORX screws.